### PR TITLE
Updates configs for WireLoad's new hosting server.

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -79,9 +79,9 @@ use Rack::Codehighlighter,
 
 activate :deploy do |deploy|
   deploy.method = :rsync
-  deploy.user = "cappuccino"
-  deploy.host = "cappuccino.slevenbits.com"
-  deploy.path = "/www/cappuccino.org/www/"
+  deploy.user = "deployer"
+  deploy.host = "se2.hosting.wireload.net"
+  deploy.path = "/www/www.cappuccino-project.org"
   deploy.clean = true
 end
 


### PR DESCRIPTION
[WireLoad](https://wireload.net) is in the process of migrating away from the old server (that `cappuccino.slevenbits.com` points to). This fix changes the deploy target to the new server.