### PR TITLE
Added blog entry "CappCon 2018 and the release of Cappuccino 1.0!"

### DIFF
--- a/source/blog/2018-04-14-cappuccino-1-0-is-announced.markdown
+++ b/source/blog/2018-04-14-cappuccino-1-0-is-announced.markdown
@@ -1,0 +1,37 @@
+---
+title: CappCon 2018 and the release of Cappuccino 1.0!
+author: Martin Carlberg 
+date: '2018-04-14'
+tags:
+- Cappuccino
+- release
+- update
+---
+
+
+#### Details
+
+This is an announcement that we will release version 1.0 of the Cappuccino frameworks on September 4, 2018 at Université de Liège in Belgium. This is exactly on the day 10 years after the first commit to GitHub.
+
+We encourage you to [come and join us in Liège, Belgium](https://www.meetup.com/CappCon/events/248886408/) on this day to celebrate and learn more about this major release of the Cappuccino frameworks. We will have speakers that show the latest and greatest features. We will also talk about why this framework makes web development easier compared to other frameworks that change all the time over the years. In the evening we will have a release party where you can meet and talk with fellow web developers. [See the meetup for details](https://www.meetup.com/CappCon/events/248886408).
+
+We don't have a fixed number of features that will be included in this release but here is a list of some candidates:
+
+1. Node support (not ready yet but aiming for the 1.0 release).
+2. New flat CSS based theme for all user interface controls. This is called Aristo 3. (not ready yet but aiming for the 1.0 release).
+3. CPTextView mimics NSTextView from Mac OS X. Brings rich text control to the framework. This is much more than traditional web text editors as it doesn’t rely much on the browser but instead actually understands content layout and formatting. This was included in the last release but is a major feature and has a lot of fixes and improvements in this release.
+4. Source Map support when debugging. Step line by line in the browser debugger using the original source files.
+5. Many bug fixes and small improvements.
+
+I'm sure there will be more features in this release and if you want something to be included please let us know. There are also issues and [pull requests on the github repository](https://github.com/cappuccino/cappuccino) where you can join in on the discussions. You can vote on issues and pull requests to let the developers know what you want to be included.
+
+We are also encouraging you to help with developing new features and fixes. If you want to help please [get involved!](http://cappuccino-project.org/contribute.html)
+
+Almost all of the developer discussions are today done on Gitter. This is why this e-mail list is very quiet. [So please join us there](https://gitter.im/cappuccino/cappuccino)
+
+The first release candidate of version 1.0 is scheduled for August 4, 2018. After that we will only accept bug fixes for the 1.0 release. Exceptions from this will be handled case by case.
+
+
+_- Martin Carlberg_
+
+[Register for CappCon 2018](https://www.meetup.com/CappCon/events/248886408) | [Join the discussion](https://gitter.im/cappuccino/cappuccino) | [Download Cappuccino](/downloads.html)


### PR DESCRIPTION
Created a new blog (as requested by @mrcarlberg) entry and took the text from
https://groups.google.com/forum/#!topic/objectivej/yiPN7EkR_mY.

I did make some minor modifications to the text to hide the hyperlinks
in the text. To make it look friendlier.